### PR TITLE
Updated packages and svg fetch fixes

### DIFF
--- a/models/CheckSvg.py
+++ b/models/CheckSvg.py
@@ -29,7 +29,7 @@ class CheckSvg:
 
             session = requests.Session()
             session.max_redirects = 3
-            response = session.get(url, headers={'User-Agent': self.user_agent})
+            response = session.get(url, headers={'User-Agent': self.user_agent}, timeout=4)
             if response:
                 self.svg_image_path = self.STORAGE_SVG_DIR+file_name_hash+".svg"
                 with open(self.STORAGE_SVG_DIR+file_name_hash+".svg", 'wb+') as out_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ idna==2.10
 itsdangerous==1.1.0
 jingtrang==0.1.2
 Jinja2==2.11.3
-lxml==4.6.5
+lxml==4.9.1
 MarkupSafe==1.1.1
 mysql-connector-python==8.0.21
-numpy==1.21.0
+numpy==1.22.0
 oscrypto==1.2.1
 pem==20.1.0
 protobuf==3.15.0

--- a/templates/jinjaTemplate/pages/main.html
+++ b/templates/jinjaTemplate/pages/main.html
@@ -406,7 +406,7 @@
                           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2 mr-2" viewBox="0 0 16 16" role="img" aria-label="Warning:">
                           <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
                         </svg>
-                          <div>Note: While your BIMI record is compliant, it doesn't include a Verified Mark Certificate that may be required by some mailbox providers.</div>
+                          <div>Note: your BIMI record, doesn't include a Verified Mark Certificate that may be required by some mailbox providers.</div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
- Update: Bump lxml from 4.6.5 to 4.9.1
- Update: Bump numpy from 1.21.0 to 1.22.0
- Fix: Issues with SVG image fetch crashes due to timeout
- Update: Message text for VMC certificate not found